### PR TITLE
implement basic prometheus metric endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ Flask
 Flask-SQLAlchemy
 Flask-Migrate
 flask-restx
+prometheus-flask-exporter
 psycopg2-binary
 requests


### PR DESCRIPTION
Leveraging https://pypi.org/project/prometheus-flask-exporter/ to implement a basic prometheus metric endpoint.
This by default scrapes data about request count and latencies for individual routes.
Will be useful for monitoring.